### PR TITLE
[Feature] 카테고리별 쿠폰 가져오기 기능 구현

### DIFF
--- a/src/main/java/com/T82/coupon/controller/CouponController.java
+++ b/src/main/java/com/T82/coupon/controller/CouponController.java
@@ -31,7 +31,7 @@ public class CouponController {
      * 카테고리별로 쿠폰 가져오기(페이징 5개씩)
      */
     @GetMapping("/coupons")
-    public Page<CouponResponseDto> getCouponsByCategory(@RequestParam(value = "category", required = false) Category category,
+    public Page<CouponResponseDto> getCouponsByCategory(@RequestParam(value = "category", required = false) String category,
                                                     @PageableDefault(size =5, page = 0,sort = "validEnd", direction = Sort.Direction.ASC) Pageable pageRequest){
         return couponService.getCouponsByCategory(category,pageRequest);
     }

--- a/src/main/java/com/T82/coupon/controller/CouponController.java
+++ b/src/main/java/com/T82/coupon/controller/CouponController.java
@@ -1,8 +1,14 @@
 package com.T82.coupon.controller;
 
-import com.T82.coupon.dto.request.CreateCouponRequestDto;
+import com.T82.coupon.dto.request.CouponRequestDto;
+import com.T82.coupon.dto.response.CouponResponseDto;
+import com.T82.coupon.global.domain.enums.Category;
 import com.T82.coupon.service.CouponService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,10 +18,22 @@ import org.springframework.web.bind.annotation.*;
 public class CouponController {
     private final CouponService couponService;
 
+    /**
+     * 쿠폰 생성
+     */
     @PostMapping("/coupons")
     @ResponseStatus(HttpStatus.OK)
-    public void createCoupon(@RequestBody CreateCouponRequestDto req){
+    public void createCoupon(@RequestBody CouponRequestDto req){
         couponService.createCoupon(req);
     };
+
+    /**
+     * 카테고리별로 쿠폰 가져오기(페이징 5개씩)
+     */
+    @GetMapping("/coupons")
+    public Page<CouponResponseDto> getCouponsByCategory(@RequestParam(value = "category", required = false) Category category,
+                                                    @PageableDefault(size =5, page = 0,sort = "validEnd", direction = Sort.Direction.ASC) Pageable pageRequest){
+        return couponService.getCouponsByCategory(category,pageRequest);
+    }
 
 }

--- a/src/main/java/com/T82/coupon/controller/ExceptionController.java
+++ b/src/main/java/com/T82/coupon/controller/ExceptionController.java
@@ -1,5 +1,6 @@
 package com.T82.coupon.controller;
 
+import com.T82.coupon.global.domain.exception.CategoryNotFoundException;
 import com.T82.coupon.global.domain.exception.CouponNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -14,5 +15,9 @@ public class ExceptionController {
         return e.getMessage();
     }
 
-
+    @ExceptionHandler(CategoryNotFoundException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String categoryNotFoundExceptionHandler(CategoryNotFoundException e){
+        return e.getMessage();
+    }
 }

--- a/src/main/java/com/T82/coupon/dto/request/CouponRequestDto.java
+++ b/src/main/java/com/T82/coupon/dto/request/CouponRequestDto.java
@@ -7,7 +7,7 @@ import com.T82.coupon.global.domain.enums.DiscountType;
 import java.util.Date;
 import java.util.UUID;
 
-public record CreateCouponRequestDto(
+public record CouponRequestDto(
         String couponName,
         DiscountType discountType,
         Integer discountValue,
@@ -17,7 +17,7 @@ public record CreateCouponRequestDto(
         Category category
 
 ) {
-    public Coupon toEntity(CreateCouponRequestDto req){
+    public Coupon toEntity(CouponRequestDto req){
         return Coupon.builder()
                 .couponId(UUID.randomUUID())
                 .couponName(req.couponName)

--- a/src/main/java/com/T82/coupon/dto/response/CouponResponseDto.java
+++ b/src/main/java/com/T82/coupon/dto/response/CouponResponseDto.java
@@ -1,0 +1,34 @@
+package com.T82.coupon.dto.response;
+
+import com.T82.coupon.dto.request.CouponRequestDto;
+import com.T82.coupon.global.domain.entity.Coupon;
+import com.T82.coupon.global.domain.enums.Category;
+import com.T82.coupon.global.domain.enums.DiscountType;
+
+import java.util.Date;
+import java.util.UUID;
+
+public record CouponResponseDto(
+        UUID couponId,
+        String couponName,
+        DiscountType discountType,
+        Integer discountValue,
+        Date validEnd,
+        Integer minPurchase,
+        Boolean duplicate,
+        Category category
+
+){
+    public static CouponResponseDto from(Coupon coupon) {
+        return new CouponResponseDto(
+                coupon.getCouponId(),
+                coupon.getCouponName(),
+                coupon.getDiscountType(),
+                coupon.getDiscountValue(),
+                coupon.getValidEnd(),
+                coupon.getMinPurchase(),
+                coupon.getDuplicate(),
+                coupon.getCategory()
+        );
+    }
+}

--- a/src/main/java/com/T82/coupon/global/domain/enums/Category.java
+++ b/src/main/java/com/T82/coupon/global/domain/enums/Category.java
@@ -3,5 +3,6 @@ package com.T82.coupon.global.domain.enums;
 public enum Category {
     MUSICAL,
     CONCERT,
-    SPORTS
+    SPORTS,
+    ALL
 }

--- a/src/main/java/com/T82/coupon/global/domain/enums/Category.java
+++ b/src/main/java/com/T82/coupon/global/domain/enums/Category.java
@@ -1,8 +1,20 @@
 package com.T82.coupon.global.domain.enums;
 
+import com.T82.coupon.global.domain.exception.CategoryNotFoundException;
+
 public enum Category {
     MUSICAL,
     CONCERT,
     SPORTS,
-    ALL
+    ALL;
+    public static Category from(String str){
+        str = str.toUpperCase();
+        return switch (str) {
+            case "MUSICAL" -> Category.MUSICAL;
+            case "CONCERT" -> Category.CONCERT;
+            case "SPORTS" -> Category.SPORTS;
+            case "ALL" -> Category.ALL;
+            default -> throw new CategoryNotFoundException();
+        };
+    }
 }

--- a/src/main/java/com/T82/coupon/global/domain/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/T82/coupon/global/domain/exception/CategoryNotFoundException.java
@@ -1,0 +1,7 @@
+package com.T82.coupon.global.domain.exception;
+
+public class CategoryNotFoundException extends IllegalArgumentException{
+    public CategoryNotFoundException() {
+        super("Not Fount Category");
+    }
+}

--- a/src/main/java/com/T82/coupon/global/domain/repository/CouponRepository.java
+++ b/src/main/java/com/T82/coupon/global/domain/repository/CouponRepository.java
@@ -1,7 +1,16 @@
 package com.T82.coupon.global.domain.repository;
 
 import com.T82.coupon.global.domain.entity.Coupon;
+import com.T82.coupon.global.domain.enums.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface CouponRepository extends JpaRepository<Coupon, Long> {
+import java.util.UUID;
+
+public interface CouponRepository extends JpaRepository<Coupon, UUID> {
+    @Query("select c from Coupon c where c.category=:category")
+    Page<Coupon> findAllByCategory(@Param("category") Category category, Pageable pageRequest);
 }

--- a/src/main/java/com/T82/coupon/service/CouponService.java
+++ b/src/main/java/com/T82/coupon/service/CouponService.java
@@ -9,5 +9,5 @@ import org.springframework.data.domain.Pageable;
 public interface CouponService {
     void createCoupon(CouponRequestDto req);
 
-    Page<CouponResponseDto> getCouponsByCategory(Category category, Pageable pageRequest);
+    Page<CouponResponseDto> getCouponsByCategory(String category, Pageable pageRequest);
 }

--- a/src/main/java/com/T82/coupon/service/CouponService.java
+++ b/src/main/java/com/T82/coupon/service/CouponService.java
@@ -1,7 +1,13 @@
 package com.T82.coupon.service;
 
-import com.T82.coupon.dto.request.CreateCouponRequestDto;
+import com.T82.coupon.dto.request.CouponRequestDto;
+import com.T82.coupon.dto.response.CouponResponseDto;
+import com.T82.coupon.global.domain.enums.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface CouponService {
-    void createCoupon(CreateCouponRequestDto req);
+    void createCoupon(CouponRequestDto req);
+
+    Page<CouponResponseDto> getCouponsByCategory(Category category, Pageable pageRequest);
 }

--- a/src/main/java/com/T82/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/com/T82/coupon/service/CouponServiceImpl.java
@@ -1,10 +1,14 @@
 package com.T82.coupon.service;
 
-import com.T82.coupon.dto.request.CreateCouponRequestDto;
+import com.T82.coupon.dto.request.CouponRequestDto;
+import com.T82.coupon.dto.response.CouponResponseDto;
 import com.T82.coupon.global.domain.entity.Coupon;
+import com.T82.coupon.global.domain.enums.Category;
 import com.T82.coupon.global.domain.repository.CouponRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,7 +17,13 @@ import org.springframework.stereotype.Service;
 public class CouponServiceImpl implements CouponService{
     private final CouponRepository couponRepository;
     @Override
-    public void createCoupon(CreateCouponRequestDto req) {
+    public void createCoupon(CouponRequestDto req) {
         couponRepository.save(req.toEntity(req));
+    }
+
+    @Override
+    public Page<CouponResponseDto> getCouponsByCategory(Category category, Pageable pageRequest) {
+        Page<Coupon> allByCategory = couponRepository.findAllByCategory(category, pageRequest);
+        return allByCategory.map(CouponResponseDto::from);
     }
 }

--- a/src/main/java/com/T82/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/com/T82/coupon/service/CouponServiceImpl.java
@@ -22,8 +22,8 @@ public class CouponServiceImpl implements CouponService{
     }
 
     @Override
-    public Page<CouponResponseDto> getCouponsByCategory(Category category, Pageable pageRequest) {
-        Page<Coupon> allByCategory = couponRepository.findAllByCategory(category, pageRequest);
+    public Page<CouponResponseDto> getCouponsByCategory(String category, Pageable pageRequest) {
+        Page<Coupon> allByCategory = couponRepository.findAllByCategory(Category.from(category), pageRequest);
         return allByCategory.map(CouponResponseDto::from);
     }
 }

--- a/src/test/java/com/T82/coupon/service/CouponServiceImplTest.java
+++ b/src/test/java/com/T82/coupon/service/CouponServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.T82.coupon.service;
 
-import com.T82.coupon.dto.request.CreateCouponRequestDto;
+import com.T82.coupon.dto.request.CouponRequestDto;
 import com.T82.coupon.global.domain.enums.Category;
 import com.T82.coupon.global.domain.enums.DiscountType;
 import com.T82.coupon.global.domain.repository.CouponRepository;
@@ -31,7 +31,7 @@ class CouponServiceImplTest {
         @Test
         void 쿠폰생성_성공() {
 //    given
-            CreateCouponRequestDto coupon = new CreateCouponRequestDto("테스트쿠폰", DiscountType.FIXED, 1000, Date.from(Instant.parse("2024-12-31T23:59:59.00Z.")) , 10000, true, Category.SPORTS);
+            CouponRequestDto coupon = new CouponRequestDto("테스트쿠폰", DiscountType.FIXED, 1000, Date.from(Instant.parse("2024-12-31T23:59:59.00Z.")) , 10000, true, Category.SPORTS);
             int lengthBefore = couponRepository.findAll().size();
 //    when
             couponService.createCoupon(coupon);

--- a/src/test/java/com/T82/coupon/service/CouponServiceImplTest.java
+++ b/src/test/java/com/T82/coupon/service/CouponServiceImplTest.java
@@ -4,6 +4,7 @@ import com.T82.coupon.dto.request.CouponRequestDto;
 import com.T82.coupon.dto.response.CouponResponseDto;
 import com.T82.coupon.global.domain.enums.Category;
 import com.T82.coupon.global.domain.enums.DiscountType;
+import com.T82.coupon.global.domain.exception.CategoryNotFoundException;
 import com.T82.coupon.global.domain.repository.CouponRepository;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Instant;
 import java.util.Date;
 
+import static com.T82.coupon.global.domain.enums.Category.SPORTS;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
@@ -36,7 +38,7 @@ class CouponServiceImplTest {
         @Test
         void 쿠폰생성_성공() {
 //    given
-            CouponRequestDto coupon = new CouponRequestDto("테스트쿠폰", DiscountType.FIXED, 1000, Date.from(Instant.parse("2024-12-31T23:59:59.59Z")) , 10000, true, Category.SPORTS);
+            CouponRequestDto coupon = new CouponRequestDto("테스트쿠폰", DiscountType.FIXED, 1000, Date.from(Instant.parse("2024-12-31T23:59:59.59Z")) , 10000, true, SPORTS);
             int lengthBefore = couponRepository.findAll().size();
 //    when
             couponService.createCoupon(coupon);
@@ -49,11 +51,11 @@ class CouponServiceImplTest {
     @Transactional
     class 카테고리별_쿠폰_가져오기 {
         @Test
-        void 페이징_테스트() {
+        void 페이징_테스트_성공() {
             // given
-            CouponRequestDto coupon1 = new CouponRequestDto("테스트쿠폰1", DiscountType.FIXED, 1000, Date.from(Instant.parse("2024-12-31T23:58:59.00Z")), 10000, true, Category.SPORTS);
-            CouponRequestDto coupon2 = new CouponRequestDto("테스트쿠폰2", DiscountType.FIXED, 2000, Date.from(Instant.parse("2024-12-31T23:59:59.00Z")), 20000, true, Category.SPORTS);
-            CouponRequestDto coupon3 = new CouponRequestDto("테스트쿠폰3", DiscountType.PERCENTAGE, 15, Date.from(Instant.parse("2024-12-31T23:59:59.00Z")), 5000, true, Category.SPORTS);
+            CouponRequestDto coupon1 = new CouponRequestDto("테스트쿠폰1", DiscountType.FIXED, 1000, Date.from(Instant.parse("2024-12-31T23:58:59.00Z")), 10000, true, SPORTS);
+            CouponRequestDto coupon2 = new CouponRequestDto("테스트쿠폰2", DiscountType.FIXED, 2000, Date.from(Instant.parse("2024-12-31T23:59:59.00Z")), 20000, true, SPORTS);
+            CouponRequestDto coupon3 = new CouponRequestDto("테스트쿠폰3", DiscountType.PERCENTAGE, 15, Date.from(Instant.parse("2024-12-31T23:59:59.00Z")), 5000, true, SPORTS);
 
             couponRepository.save(coupon1.toEntity(coupon1));
             couponRepository.save(coupon2.toEntity(coupon2));
@@ -61,21 +63,34 @@ class CouponServiceImplTest {
 
             // when
             Pageable pageable = PageRequest.of(0, 2);
-            Page<CouponResponseDto> result = couponService.getCouponsByCategory(Category.SPORTS, pageable);
 
+            Page<CouponResponseDto> result = couponService.getCouponsByCategory(String.valueOf(SPORTS), pageable);
             // then
             assertEquals(2, result.getNumberOfElements());
             assertEquals(3, result.getTotalElements());
             assertEquals(2, result.getTotalPages());
-            assertTrue(result.getContent().stream().allMatch(coupon -> coupon.category() == Category.SPORTS));
+            assertTrue(result.getContent().stream().allMatch(coupon -> coupon.category() == SPORTS));
             // 쿠폰이 날짜 순으로 정렬되었는지 확인
             assertTrue(result.getContent().get(0).validEnd().before(result.getContent().get(1).validEnd()));
 
             // 추가로 다른 페이지를 요청하여 내용 확인
             Pageable pageableSecondPage = PageRequest.of(1, 2);
-            Page<CouponResponseDto> resultSecondPage = couponService.getCouponsByCategory(Category.SPORTS, pageableSecondPage);
+            Page<CouponResponseDto> resultSecondPage = couponService.getCouponsByCategory(String.valueOf(SPORTS), pageableSecondPage);
 
             assertEquals(1, resultSecondPage.getNumberOfElements());
+        }
+
+        @Test
+        void 없는_Categroy값이_들어왔을때_실패_테스트() {
+            // given
+            CouponRequestDto coupon1 = new CouponRequestDto("테스트쿠폰3", DiscountType.PERCENTAGE, 15, Date.from(Instant.parse("2024-12-31T23:59:59.00Z")), 5000, true, SPORTS);
+            couponRepository.save(coupon1.toEntity(coupon1));
+
+            // when
+            Pageable pageable = PageRequest.of(0, 5); // 페이지 크기를 크게 지정하여 모든 결과를 가져오도록 함
+            CategoryNotFoundException categoryNotFoundException = assertThrows(CategoryNotFoundException.class,()-> couponService.getCouponsByCategory(String.valueOf(Category.from("hi")), pageable)); // 존재하지 않는 category값 전달
+            // then
+            assertEquals("Not Fount Category",categoryNotFoundException.getMessage());
         }
     }
 }

--- a/src/test/java/com/T82/coupon/service/CouponServiceImplTest.java
+++ b/src/test/java/com/T82/coupon/service/CouponServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.T82.coupon.service;
 
 import com.T82.coupon.dto.request.CouponRequestDto;
+import com.T82.coupon.dto.response.CouponResponseDto;
 import com.T82.coupon.global.domain.enums.Category;
 import com.T82.coupon.global.domain.enums.DiscountType;
 import com.T82.coupon.global.domain.repository.CouponRepository;
@@ -8,6 +9,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,13 +36,46 @@ class CouponServiceImplTest {
         @Test
         void 쿠폰생성_성공() {
 //    given
-            CouponRequestDto coupon = new CouponRequestDto("테스트쿠폰", DiscountType.FIXED, 1000, Date.from(Instant.parse("2024-12-31T23:59:59.00Z.")) , 10000, true, Category.SPORTS);
+            CouponRequestDto coupon = new CouponRequestDto("테스트쿠폰", DiscountType.FIXED, 1000, Date.from(Instant.parse("2024-12-31T23:59:59.59Z")) , 10000, true, Category.SPORTS);
             int lengthBefore = couponRepository.findAll().size();
 //    when
             couponService.createCoupon(coupon);
 //    then
             assertEquals(couponRepository.findAll().size(),lengthBefore + 1);
         }
+    }
 
+    @Nested
+    @Transactional
+    class 카테고리별_쿠폰_가져오기 {
+        @Test
+        void 페이징_테스트() {
+            // given
+            CouponRequestDto coupon1 = new CouponRequestDto("테스트쿠폰1", DiscountType.FIXED, 1000, Date.from(Instant.parse("2024-12-31T23:58:59.00Z")), 10000, true, Category.SPORTS);
+            CouponRequestDto coupon2 = new CouponRequestDto("테스트쿠폰2", DiscountType.FIXED, 2000, Date.from(Instant.parse("2024-12-31T23:59:59.00Z")), 20000, true, Category.SPORTS);
+            CouponRequestDto coupon3 = new CouponRequestDto("테스트쿠폰3", DiscountType.PERCENTAGE, 15, Date.from(Instant.parse("2024-12-31T23:59:59.00Z")), 5000, true, Category.SPORTS);
+
+            couponRepository.save(coupon1.toEntity(coupon1));
+            couponRepository.save(coupon2.toEntity(coupon2));
+            couponRepository.save(coupon3.toEntity(coupon3));
+
+            // when
+            Pageable pageable = PageRequest.of(0, 2);
+            Page<CouponResponseDto> result = couponService.getCouponsByCategory(Category.SPORTS, pageable);
+
+            // then
+            assertEquals(2, result.getNumberOfElements());
+            assertEquals(3, result.getTotalElements());
+            assertEquals(2, result.getTotalPages());
+            assertTrue(result.getContent().stream().allMatch(coupon -> coupon.category() == Category.SPORTS));
+            // 쿠폰이 날짜 순으로 정렬되었는지 확인
+            assertTrue(result.getContent().get(0).validEnd().before(result.getContent().get(1).validEnd()));
+
+            // 추가로 다른 페이지를 요청하여 내용 확인
+            Pageable pageableSecondPage = PageRequest.of(1, 2);
+            Page<CouponResponseDto> resultSecondPage = couponService.getCouponsByCategory(Category.SPORTS, pageableSecondPage);
+
+            assertEquals(1, resultSecondPage.getNumberOfElements());
+        }
     }
 }


### PR DESCRIPTION
## 개요
카테고리별로 쿠폰을 가져오는 기능을 구현하였습니다.

## 주요 추가 사항
- Param으로 카테고리를 전달하면 해당 카테고리의 쿠폰을 가져옴
- 5개씩 가져오도록 페이징 처리
- 성공 테스트 케이스
- 실패 테스트 케이스 (Param이 Enum타입에 없는 값이 들어왔을때)

## 기능 설명
1. **API 엔드포인트 추가**
   - GET `/api/v1/coupons?category=musical`
