### PR TITLE
[Feature] 유효기간이 현재 시간 이전까지인 쿠폰은 반환하지 않도록하는 기능 추가(#6)

### DIFF
--- a/src/main/java/com/T82/coupon/global/domain/repository/CouponRepository.java
+++ b/src/main/java/com/T82/coupon/global/domain/repository/CouponRepository.java
@@ -11,6 +11,6 @@ import org.springframework.data.repository.query.Param;
 import java.util.UUID;
 
 public interface CouponRepository extends JpaRepository<Coupon, UUID> {
-    @Query("select c from Coupon c where c.category=:category")
+    @Query("select c from Coupon c where c.category=:category and c.validEnd > current_date")
     Page<Coupon> findAllByCategory(@Param("category") Category category, Pageable pageRequest);
 }


### PR DESCRIPTION
## 개요
카테고리별로 쿠폰을 가져오는 기능을 구현하였습니다.

## 주요 추가 사항
- Param으로 카테고리를 전달하면 해당 카테고리의 쿠폰을 가져옴
- 5개씩 가져오도록 페이징 처리
- 성공 테스트 케이스
- 실패 테스트 케이스 (Param이 Enum타입에 없는 값이 들어왔을때)

## 기능 설명
1. **API 엔드포인트 추가**
   - GET `/api/v1/coupons?category=musical`
