### PR TITLE
[Fix] 에러 처리 및 로깅 라이브러리 사용으로 전환 (#28)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -29,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.kafka:spring-kafka'
+	implementation 'com.github.T82-encore:T82-Common-Exception:v0.8.14'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'

--- a/src/test/java/com/T82/coupon/service/CouponServiceImplTest.java
+++ b/src/test/java/com/T82/coupon/service/CouponServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.T82.coupon.service;
 
+import com.T82.common_exception.exception.CustomException;
 import com.T82.coupon.dto.request.CouponRequestDto;
 import com.T82.coupon.dto.request.CouponVerifyRequestDto;
 import com.T82.coupon.dto.request.UseCouponRequestDto;
@@ -158,7 +159,7 @@ class CouponServiceImplTest {
             UserDto principal = (UserDto) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
             // when & then
-            assertThrows(CouponNotFoundException.class, () -> {
+            assertThrows(CustomException.class, () -> {
                 couponService.giveCouponToUser(couponId, principal);
             });
         }
@@ -289,7 +290,7 @@ class CouponServiceImplTest {
             );
 
             // when & then
-            assertThrows(MinPurchaseException.class, () -> couponService.verifyCoupons(new CouponVerifyRequestDto(userId, couponUsages)));
+            assertThrows(CustomException.class, () -> couponService.verifyCoupons(new CouponVerifyRequestDto(userId, couponUsages)));
         }
         @Test
         void 사용완료_쿠폰_실패_테스트() {
@@ -315,7 +316,7 @@ class CouponServiceImplTest {
             );
 
             // when & then
-            assertThrows(ExpiredCouponException.class, () -> couponService.verifyCoupons(new CouponVerifyRequestDto(userId, couponUsages)));
+            assertThrows(CustomException.class, () -> couponService.verifyCoupons(new CouponVerifyRequestDto(userId, couponUsages)));
         }
         @Test
         void 쿠폰_만료_실패테스트() {
@@ -353,7 +354,7 @@ class CouponServiceImplTest {
             );
 
             // when & then
-            assertThrows(ExpiredCouponException.class, () -> couponService.verifyCoupons(new CouponVerifyRequestDto(userId, couponUsages)));
+            assertThrows(CustomException.class, () -> couponService.verifyCoupons(new CouponVerifyRequestDto(userId, couponUsages)));
         }
     }
 


### PR DESCRIPTION
## 개요
에러 처리 및 로깅을 자체 라이브러리를 사용하는 것으로 전환하였습니다.

## 주요 변경 사항
- 에러 처리를 라이브러리를 사용하여 통일 시켰습니다.
- 로깅을 라이브러리를 사용하여 통일 시켰습니다.

## 기능 설명
build.gradle에

```
repositories {
	mavenCentral()
	maven { url 'https://jitpack.io' }
}
```
추가

dependencies에 
```
implementation 'com.github.T82-encore:T82-Common-Exception:v0.8.14' 
```
추가
```
    @Override
    @CustomException(ErrorCode.COUPON_NOT_FOUND)
    public void giveCouponToUser(String couponId, UserDto userDto) {
        Coupon coupon = couponRepository.findById(UUID.fromString(couponId)).orElseThrow(IllegalArgumentException::new);
        couponBoxRepository.save(CouponBox.toEntity(coupon, userDto.getId()));
    }
```
다음과 같이 어노테이션 적용으로 에러를 처리할 수 있게 전환하였습니다.