### PR TITLE
Fix: 기존의 Exception Class들 삭제(#28)

### DIFF
--- a/src/main/java/com/T82/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/com/T82/coupon/service/CouponServiceImpl.java
@@ -12,7 +12,6 @@ import com.T82.coupon.global.domain.entity.Coupon;
 import com.T82.coupon.global.domain.entity.CouponBox;
 import com.T82.coupon.global.domain.enums.Category;
 import com.T82.coupon.global.domain.enums.Status;
-import com.T82.coupon.global.domain.exception.*;
 import com.T82.coupon.global.domain.repository.CouponBoxRepository;
 import com.T82.coupon.global.domain.repository.CouponRepository;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## 개요
기존 Exception Handler와 Exception Class들을 사용하였는데 라이브러리의 어노테이션 기반으로 예외를 처리하면서 삭제하였습니다.

## 주요 변경 사항
- Exception Handler 삭제
- Exception Class 삭제