### PR TITLE
[Fix] Kafka DLT추가(#35)

### DIFF
--- a/src/main/java/com/T82/coupon/global/config/KafkaConfig.java
+++ b/src/main/java/com/T82/coupon/global/config/KafkaConfig.java
@@ -1,0 +1,26 @@
+package com.T82.coupon.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.retrytopic.DltStrategy;
+import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
+import org.springframework.kafka.retrytopic.RetryTopicConfigurationBuilder;
+import org.springframework.kafka.retrytopic.TopicSuffixingStrategy;
+
+@Configuration
+public class KafkaConfig {
+
+    @Bean
+    public RetryTopicConfiguration retryableTopic(KafkaTemplate<String, Object> template) {
+        return RetryTopicConfigurationBuilder
+                .newInstance()
+                .maxAttempts(3)
+                .exponentialBackoff(10 * 1000L, 2, 5 * 60 * 1000L)
+                .autoCreateTopics(true, 3, (short) 3)
+                .retryOn(IllegalArgumentException.class)
+                .setTopicSuffixingStrategy(TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE)
+                .dltProcessingFailureStrategy(DltStrategy.ALWAYS_RETRY_ON_ERROR)
+                .create(template);
+    }
+}


### PR DESCRIPTION
## 개요
Kafka에서 쿠폰 발행도중 실패했을때 계속 가져오려고 시도하는 문제가 발생하여 DLT를 추가하여 해결하였습니다.

## 주요 변경 사항
- Kafka Config에 DLT에 관련된 내용 추가
- Kafka Listenser에 DLT관련된 내용 추가